### PR TITLE
Fix types based on dialyzer checks

### DIFF
--- a/src/soap.hrl
+++ b/src/soap.hrl
@@ -25,7 +25,7 @@
     name :: string(),
     operation :: atom(), %% name of function as used in handler module
     soap_action = [] :: string(),
-    wrapper_ns = [] :: string(), %% namespace for the wrapper element (in 
+    wrapper_ns = [] :: string() | undefined, %% namespace for the wrapper element (in 
                                  %% case of rpc style)
     op_type :: notification | request_response,
     in_type :: [{string(), atom()}]  | atom(), %% the list type is only used
@@ -47,7 +47,7 @@
     target_ns :: string(),
     soap_ns :: string(),
     style :: string() | undefined, %% "rpc" | "document" 
-    decoders :: [{string(), module}], 
+    decoders :: [{string(), module}] | undefined, 
     url :: string(),
     port :: string(),
     binding :: string(),

--- a/src/soap_client_util.erl
+++ b/src/soap_client_util.erl
@@ -55,7 +55,7 @@
     fault_parser :: fun(),
     parser_state :: any(),
     soap_headers = [] :: [string() | tuple()],
-    soap_body :: string(),
+    soap_body :: string() | tuple(),
     is_fault = false :: boolean(),
     namespaces = [] :: [{prefix(), uri()}]
 }).


### PR DESCRIPTION
I found this bugs, while running dialyzer for the project that uses soap. While the change might not reflect what was the initial intention of the types for those fields - it at least reflect the current code. 

So we might end up with `undefined` value in `wrapper_ns` field because of that code: https://github.com/bet365/soap/blob/master/src/soap_parse_wsdl.erl#L337 and decoders just don't have any default falue. So you might wanna change it to `decoders = [] :: [{string(), module}]` instead of having `undefined` there. 