### PR TITLE
Provide extra callbacks for cowboy protocol 1,2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ct: compile test_deps
 	-@ct_run -noshell -pa ebin \
 		-pa deps/*/ebin \
 		-pa test/deps/*/ebin \
-		-name test \
+		-sname test \
 		-logdir ./logs \
 		-env TEST_DIR ./test \
 		-spec ./test/test_specs.spec \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ compile:
 	@rebar compile
 
 ct: compile test_deps
+	mkdir -p ./logs
 	@echo "Running common tests..."
 	-@ct_run -noshell -pa ebin \
 		-pa deps/*/ebin \

--- a/src/soap_cowboy_1_protocol.erl
+++ b/src/soap_cowboy_1_protocol.erl
@@ -27,7 +27,7 @@
 -module(soap_cowboy_1_protocol).
 %% -behaviour(cowboy_sub_protocol).
 
--export([upgrade/4]).
+-export([upgrade/4, upgrade/5]).
 -export([enrich_req/2]).
 -export([respond/4]).
 
@@ -48,9 +48,19 @@
               {Implementation_handler::module(), Options::any()}) -> 
     {ok, cowboy_req(), cowboy_env()}. 
 upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}) ->
-    soap_cowboy_protocol:upgrade(Cowboy_req, Env, Soap_handler, 
-                                 {Handler, Options}, cowboy_1, ?MODULE).
+  {ok, Message, Cowboy_req2} = cowboy_req:body(Cowboy_req),
+  upgrade(Cowboy_req2, Env, Soap_handler, {Handler, Options}, Message).
 
+%% There might exist middleware that reads body from the cowboy_req, in which 
+%% case it will be no longer available while calling upgrade/4. In this case
+%% you are responsible for propogating Body directly to upgrade/5
+-spec upgrade(Cowboy_req::cowboy_req(), Env::cowboy_env(),
+              Soap_handler::module(), 
+              {Implementation_handler::module(), Options::any()}, Body::binary()) -> 
+                                                               {ok, cowboy_req(), cowboy_env()}. 
+upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}, Message) ->
+  soap_cowboy_protocol:upgrade(Cowboy_req, Env, Soap_handler, 
+                               {Handler, Options}, cowboy_1, ?MODULE, Message).
 
 enrich_req(Cowboy_req, Soap_req) ->
   {Method, Req2} = cowboy_req:method(Cowboy_req),

--- a/src/soap_cowboy_2_protocol.erl
+++ b/src/soap_cowboy_2_protocol.erl
@@ -29,7 +29,7 @@
 -module(soap_cowboy_2_protocol).
 %%-behaviour(cowboy_sub_protocol).
 
--export([upgrade/6, upgrade/7]).
+-export([upgrade/4, upgrade/5]).
 -export([enrich_req/2]).
 -export([respond/4]).
 
@@ -46,19 +46,18 @@
 %% This callback is expected to behave like a middleware and to return an
 %% updated req object and environment.
 -spec upgrade(Cowboy_req::cowboy_req(), Env::cowboy_env(),
-              Soap_handler::module(), {Implementation_handler::module(), Options::any()},
-              Timeout::any(), Hibernate::any()) -> {ok, cowboy_req(), cowboy_env()}. 
-upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}, Timeout, Hibernate) ->
-  {ok, Message, Cowboy_req2} = cowboy_req:body(Cowboy_req),
-  upgrade(Cowboy_req2, Env, Soap_handler, {Handler, Options}, Timeout, Hibernate, Message).
+              Soap_handler::module(), {Implementation_handler::module(), Options::any()})
+               -> {ok, cowboy_req(), cowboy_env()}.
+upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}) ->
+  {ok, Message, Cowboy_req2} = cowboy_req:read_body(Cowboy_req),
+  upgrade(Cowboy_req2, Env, Soap_handler, {Handler, Options}, Message).
 
-%% There might exist middleware that reads body from the cowboy_req, in which 
-%% case it will be no longer available while calling upgrade/6. In this case
-%% you are responsible for propogating Body directly to upgrade/7
-upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}, _, _, Message) ->
-  soap_cowboy_protocol:upgrade(Cowboy_req, Env, Soap_handler, 
+%% There might exist middleware that reads body from the cowboy_req, in which
+%% case it will be no longer available while calling upgrade/4. In this case
+%% you are responsible for propogating Body directly to upgrade/5
+upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}, Message) ->
+  soap_cowboy_protocol:upgrade(Cowboy_req, Env, Soap_handler,
                                {Handler, Options}, cowboy_2, ?MODULE, Message).
-
 
 enrich_req(Cowboy_req, Soap_req) ->
   Method = cowboy_req:method(Cowboy_req),

--- a/src/soap_cowboy_protocol.erl
+++ b/src/soap_cowboy_protocol.erl
@@ -28,7 +28,7 @@
 
 -module(soap_cowboy_protocol).
 
--export([upgrade/6]).
+-export([upgrade/7]).
 
 -record(state, {
   env :: cowboy_middleware:env(),
@@ -51,12 +51,12 @@
 -spec upgrade(Cowboy_req::cowboy_req(), Env::cowboy_env(),
               Soap_handler::module(), {Implementation_handler::module(), Options::any()},
               Version::atom(),
-              Version_module::module()) -> {ok, cowboy_req(), cowboy_env()}. 
-upgrade(Cowboy_req, Env, _, {Handler, Options}, Version, Version_module) ->
+              Version_module::module(), Body::binary()) -> {ok, cowboy_req(), cowboy_env()}. 
+upgrade(Cowboy_req, Env, _, {Handler, Options}, Version, Version_module, Body) ->
   Cowboy_state = #state{env = Env, handler = Handler},
   case soap_server_handler:new_req(Handler, Version, Options, Cowboy_req) of
     {continue, Soap_req} ->
-      check_conformance(Soap_req, Cowboy_req, Cowboy_state, Version_module);
+      check_conformance(Soap_req, Cowboy_req, Cowboy_state, Version_module, Body);
     {ok, _StatusCode, _Headers, _Body, _Server_req} = Error ->
       make_response(Error, Cowboy_state, Version_module)
   end.
@@ -65,25 +65,22 @@ upgrade(Cowboy_req, Env, _, {Handler, Options}, Version, Version_module) ->
 %%% Internal functions
 %%% ============================================================================
 
-check_conformance(Soap_req, Cowboy_req, Cowboy_state, Version_module) ->
+check_conformance(Soap_req, Cowboy_req, Cowboy_state, Version_module, Body) ->
   %% collect some information about the protocol, so that 
   %% conformance can be checked.
   Soap_req2 = Version_module:enrich_req(Cowboy_req, Soap_req),
   case soap_server_handler:check_http_conformance(Soap_req2) of
     {continue, Soap_req3} ->
-      handle_xml(Soap_req3, Cowboy_state, Version_module);
+      handle_xml(Soap_req3, Cowboy_state, Version_module, Body);
     {ok, _StatusCode, _Headers, _Body, _Server_req} = Error ->
       make_response(Error, Cowboy_state, Version_module)
   end.
 
-handle_xml(Soap_req, Cowboy_state, Version_module) ->
-  Cowboy_req = soap_req:server_req(Soap_req),
-  {ok, Message, Cowboy_req2} = cowboy_req:body(Cowboy_req),
-  Soap_req2 = soap_req:set_server_req(Soap_req, Cowboy_req2),
-  Soap_req3 = soap_req:set_http_body(Soap_req2, Message),
-  Content_type = soap_req:content_type(Soap_req3),
+handle_xml(Soap_req, Cowboy_state, Version_module, Message) ->
+  Soap_req2 = soap_req:set_http_body(Soap_req, Message),
+  Content_type = soap_req:content_type(Soap_req2),
   %% get the soap message (Xml) from the request body
-  {Xml, Soap_req4} =
+  {Xml, Soap_req3} =
     case maybe_content_type(Content_type) of
       "multipart/related" -> 
         %% soap with attachments, the message is in the first part
@@ -92,16 +89,16 @@ handle_xml(Soap_req, Cowboy_state, Version_module) ->
             mime_decode(Message, Content_type),
             {Body, 
              soap_req:set_mime_headers(
-               soap_req:set_req_attachments(Soap_req3, Attachments), 
+               soap_req:set_req_attachments(Soap_req2, Attachments), 
                Mime_headers)}
       catch
         _Class:_Type ->
-          {Message, Soap_req3}
+          {Message, Soap_req2}
       end;
     _ ->
-      {Message, Soap_req3}
+      {Message, Soap_req2}
   end,
-  Handler_resp = soap_server_handler:handle_message(Xml, Soap_req4),
+  Handler_resp = soap_server_handler:handle_message(Xml, Soap_req3),
   make_response(Handler_resp, Cowboy_state, Version_module).
 
 maybe_content_type(undefined) ->

--- a/src/soap_server_cowboy_1.erl
+++ b/src/soap_server_cowboy_1.erl
@@ -63,17 +63,14 @@ start(Module) ->
     start(Module, []).
 
 start(Module, Options) ->
-    Port = proplists:get_value(port, Options, 8080),
-    Acceptors = proplists:get_value(nr_acceptors, Options, 100),
-    ok = application:ensure_started(crypto),
-    ok = application:ensure_started(ranch),
-    ok = application:ensure_started(cowlib),
-    ok = application:ensure_started(cowboy),
-    Dispatch = cowboy_router:compile([
-	{'_', [{'_', ?MODULE, {Module, Options}}]}]),
-    {ok, _} = cowboy:start_http(http, Acceptors, [{port, Port}], [
-		{env, [{dispatch, Dispatch}]}]).
- 
+  Port = proplists:get_value(port, Options, 8080),
+  Acceptors = proplists:get_value(nr_acceptors, Options, 100),
+  {ok, _} = application:ensure_all_started(cowboy),
+  Dispatch = cowboy_router:compile([
+                                    {'_', [{'_', ?MODULE, {Module, Options}}]}]),
+  {ok, _} = cowboy:start_http(http, Acceptors, [{port, Port}],
+                              [{env, [{dispatch, Dispatch}]}]).
+
 stop() ->
     cowboy:stop_listener(http),
     application:stop(cowboy), 

--- a/src/soap_server_cowboy_2.erl
+++ b/src/soap_server_cowboy_2.erl
@@ -65,15 +65,15 @@ start(Module) ->
 start(Module, Options) ->
     Port = proplists:get_value(port, Options, 8080),
     Acceptors = proplists:get_value(nr_acceptors, Options, 100),
-    ok = application:ensure_started(crypto),
-    ok = application:ensure_started(ranch),
-    ok = application:ensure_started(cowlib),
-    ok = application:ensure_started(cowboy),
-    Dispatch = cowboy_router:compile([
-	{'_', [{'_', ?MODULE, {Module, Options}}]}]),
-    {ok, _} = cowboy:start_http(http, Acceptors, [{port, Port}], [
-		{env, [{dispatch, Dispatch}]}]).
- 
+    {ok, _} = application:ensure_all_started(cowboy),
+    Dispatch = cowboy_router:compile(
+                 [
+                  {'_', [{'_', ?MODULE, {Module, Options}}]}]),
+
+    {ok, _} = cowboy:start_clear(http, [{port, Port}],
+                                 #{env => #{dispatch => Dispatch}}
+                                ).
+
 stop() ->
     cowboy:stop_listener(http),
     application:stop(cowboy), 

--- a/test/rebar.config
+++ b/test/rebar.config
@@ -1,8 +1,9 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-	{ibrowse, ".*", {git, "https://github.com/cmullaparthi/ibrowse.git" }},
-	{cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {branch, "1.1.x"}}},
-	{mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git" }},
+        {ibrowse, ".*", {git, "https://github.com/cmullaparthi/ibrowse.git", {tag, "v4.4.0"} }},
+%%        {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {tag, "1.1.2"}}},
+        {cowboy, ".*", {git, "https://github.com/ninenines/cowboy.git", {tag, "2.2.2"}}},
+        {mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git" }},
         {erlsom, ".*", {git, "https://github.com/willemdj/erlsom.git", {branch, "v1_4"}}}
        ]}.

--- a/test/soap_SUITE.erl
+++ b/test/soap_SUITE.erl
@@ -112,6 +112,12 @@ groups() ->
       ,{soap_11_client, [sequence], [client_11_ok ,client_11_fault]}
       ,{soap_12_client, [sequence], [client_12_ok ,client_12_fault]}
       ]}
+  ,{cowboy_middle_protocol, [sequence],
+      [correct_sms
+      ,sms_fault
+      ,sms_invalid_xml
+      ,sms_wrong_method
+      ]}
   ,{mochi_server, [sequence],
       [correct_sms
       ,sms_fault
@@ -196,6 +202,15 @@ init_per_group(cowboy_server, Config) ->
                 {"^\\+?[0-9]{4,12}$", valid},
                 {"[0-9]{13,}", throw},
                 {http_server, cowboy_version()}]),
+  Config;
+init_per_group(cowboy_middle_protocol, Config) ->
+  {ok, _} = soap:start_server(sendService_test_server, 
+               [{"[a-zA-Z]+", invalid}, 
+                {"^\\+?[0-9]{4,12}$", valid},
+                {"[0-9]{13,}", throw},
+                {http_server, test_cowboy_middle_protocol},
+                {cowboy_version, cowboy_version()}
+               ]),
   Config;
 init_per_group(inets_server, Config) ->
   {ok, _} = soap:start_server(sendService_test_server, 
@@ -298,6 +313,9 @@ end_per_group(inets_server, _Config) ->
 end_per_group(cowboy_server, _Config) ->
   soap:stop_server(sendService_test_server),
   ok;
+end_per_group(cowboy_middle_protocol, _Config) ->
+  soap:stop_server(sendService_test_server),
+  ok;
 end_per_group(tempconvert_local, _Config) ->
   soap:stop_server(tempconvert_server),
   ok;
@@ -325,21 +343,22 @@ end_per_group(_, _Config) ->
 %%--------------------------------------------------------------------      
 all() -> 
   [{group, cowboy_server},
-  {group, inets_server},
-  {group, tempconvert},
-  {group, tempconvert_12},
-  {group, client},
-  {group, soap_req},
-  {group, wsdls}, %% takes a long time
-  {group, erlang2wsdl},
-  {group, wsdl2erlang},
-  {group, attachments},
-  {group, wsdl_2_0},
-  %% for some reason the mochi server 
-  %% seems to continue answering requests after shutdown
-  %% for a while, therefore put it last.
-  {group, mochi_server},
-  issue_4_encoded
+   {group, cowboy_middle_protocol},
+   {group, inets_server},
+   {group, tempconvert},
+   {group, tempconvert_12},
+   {group, client},
+   {group, soap_req},
+   {group, wsdls}, %% takes a long time
+   {group, erlang2wsdl},
+   {group, wsdl2erlang},
+   {group, attachments},
+   {group, wsdl_2_0},
+   %% for some reason the mochi server 
+   %% seems to continue answering requests after shutdown
+   %% for a while, therefore put it last.
+   {group, mochi_server},
+   issue_4_encoded
   ].
 
 %%-------------------------------------------------------------------------

--- a/test/soap_SUITE.erl
+++ b/test/soap_SUITE.erl
@@ -903,7 +903,7 @@ cowboy_version() ->
     Info = cowboy:module_info(),
     Exports = proplists:get_value(exports, Info),
     case proplists:get_value(start_tls, Exports) of
-        4 ->
+        3 ->
             soap_server_cowboy_2;
         undefined ->
             soap_server_cowboy_1

--- a/test/test_cowboy_middle_protocol.erl
+++ b/test/test_cowboy_middle_protocol.erl
@@ -1,0 +1,61 @@
+-module(test_cowboy_middle_protocol).
+
+-export([start/1]).
+-export([start/2]).
+-export([stop/0]).
+-export([init/3, init/2]).
+-export([on_request/1]).
+-export([upgrade/4, upgrade/6]).
+
+start(Module) ->
+  start(Module, []).
+
+start(Module, Options) ->
+  
+  Port = proplists:get_value(port, Options, 8080),
+  Acceptors = proplists:get_value(nr_acceptors, Options, 100),
+  {ok, _} = application:ensure_all_started(cowboy),
+  Dispatch = cowboy_router:compile([
+                                    {'_', [{'_', ?MODULE, {Module, Options}}]}]),
+  {ok, _} = cowboy:start_http(http, Acceptors, [{port, Port}], 
+                              [ {env, [{dispatch, Dispatch}]},
+                                {onrequest, fun ?MODULE:on_request/1}
+                              ]).
+
+stop() ->
+  cowboy:stop_listener(http),
+  application:stop(cowboy), 
+  application:stop(ranch).
+
+on_request(Req0) ->
+  {ok, Body, Req1} = cowboy_req:body(Req0),
+  cowboy_req:set_meta(body, Body, Req1).
+    
+%% cowboy 1 callback
+init(_, _Req, {_Module, Options}) ->
+  %% The module 'soap_cowboy_protocol' will be called
+  %% for each request, with Module (= the handler module) and 
+  %% the options as parameter. 
+  soap_server_cowboy_1 = proplists:get_value(cowboy_version, Options),
+  {upgrade, protocol, ?MODULE}.
+
+%% cowboy 1 callback
+upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}) ->
+  Options2 = proplists:delete(cowboy_version, Options),
+  {Message, Cowboy_req2} = cowboy_req:meta(body, Cowboy_req),
+
+  soap_cowboy_1_protocol:upgrade(
+    Cowboy_req2, Env, Soap_handler, {Handler, Options2}, Message).
+
+%% cowboy 2 callback
+init(Req, {Module, Options}) ->
+  soap_server_cowboy_2 = proplists:get_value(cowboy_version, Options),
+  {?MODULE, Req, {Module, Options}}.
+
+%% cowboy 2 callback
+upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}, Timeout, Hibernate) ->
+  Options2 = proplists:delete(cowboy_version, Options),
+  {Message, Cowboy_req2} = cowboy_req:meta(body, Cowboy_req),
+
+  soap_cowboy_2_protocol:upgrade(
+    Cowboy_req2, Env, Soap_handler, {Handler, Options2}, Timeout, Hibernate, Message).

--- a/test/test_cowboy_middle_protocol.erl
+++ b/test/test_cowboy_middle_protocol.erl
@@ -1,61 +1,70 @@
 -module(test_cowboy_middle_protocol).
 
--export([start/1]).
 -export([start/2]).
 -export([stop/0]).
 -export([init/3, init/2]).
 -export([on_request/1]).
--export([upgrade/4, upgrade/6]).
+-export([execute/2]).
+-export([upgrade/4]).
 
-start(Module) ->
-  start(Module, []).
 
 start(Module, Options) ->
-  
   Port = proplists:get_value(port, Options, 8080),
-  Acceptors = proplists:get_value(nr_acceptors, Options, 100),
   {ok, _} = application:ensure_all_started(cowboy),
   Dispatch = cowboy_router:compile([
                                     {'_', [{'_', ?MODULE, {Module, Options}}]}]),
-  {ok, _} = cowboy:start_http(http, Acceptors, [{port, Port}], 
-                              [ {env, [{dispatch, Dispatch}]},
-                                {onrequest, fun ?MODULE:on_request/1}
-                              ]).
+
+  case proplists:get_value(cowboy_version, Options) of
+    soap_server_cowboy_1 ->
+      cowboy:start_http(http, 10, [{port, Port}],
+                        [ {env, [{dispatch, Dispatch}]},
+                          {onrequest, fun ?MODULE:on_request/1}
+                        ]);
+    soap_server_cowboy_2 ->
+      cowboy:start_clear(http, [{port, Port}],
+                         #{env => #{dispatch => Dispatch},
+                           middlewares => [ cowboy_router
+                                          , ?MODULE
+                                          , cowboy_handler
+                                          ]
+                          }
+                        )
+  end.
 
 stop() ->
   cowboy:stop_listener(http),
-  application:stop(cowboy), 
+  application:stop(cowboy),
   application:stop(ranch).
 
 on_request(Req0) ->
   {ok, Body, Req1} = cowboy_req:body(Req0),
   cowboy_req:set_meta(body, Body, Req1).
-    
+
+execute(Req, Env) ->
+  {ok, Body, Req1} = cowboy_req:read_body(Req),
+  {ok, Req1, maps:put(req_body, Body, Env)}.
+
 %% cowboy 1 callback
 init(_, _Req, {_Module, Options}) ->
   %% The module 'soap_cowboy_protocol' will be called
-  %% for each request, with Module (= the handler module) and 
-  %% the options as parameter. 
+  %% for each request, with Module (= the handler module) and
+  %% the options as parameter.
   soap_server_cowboy_1 = proplists:get_value(cowboy_version, Options),
   {upgrade, protocol, ?MODULE}.
-
-%% cowboy 1 callback
-upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}) ->
-  Options2 = proplists:delete(cowboy_version, Options),
-  {Message, Cowboy_req2} = cowboy_req:meta(body, Cowboy_req),
-
-  soap_cowboy_1_protocol:upgrade(
-    Cowboy_req2, Env, Soap_handler, {Handler, Options2}, Message).
 
 %% cowboy 2 callback
 init(Req, {Module, Options}) ->
   soap_server_cowboy_2 = proplists:get_value(cowboy_version, Options),
   {?MODULE, Req, {Module, Options}}.
 
-%% cowboy 2 callback
-upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}, Timeout, Hibernate) ->
-  Options2 = proplists:delete(cowboy_version, Options),
-  {Message, Cowboy_req2} = cowboy_req:meta(body, Cowboy_req),
-
-  soap_cowboy_2_protocol:upgrade(
-    Cowboy_req2, Env, Soap_handler, {Handler, Options2}, Timeout, Hibernate, Message).
+upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options}) ->
+  case proplists:get_value(cowboy_version, Options) of
+    soap_server_cowboy_1 ->
+      Options2 = proplists:delete(cowboy_version, Options),
+      {Message, Cowboy_req2} = cowboy_req:meta(body, Cowboy_req),
+      soap_cowboy_1_protocol:upgrade(Cowboy_req2, Env, Soap_handler, {Handler, Options2}, Message);
+    soap_server_cowboy_2 ->
+      Options2 = proplists:delete(cowboy_version, Options),
+      Message = maps:get(req_body, Env),
+      soap_cowboy_2_protocol:upgrade(Cowboy_req, Env, Soap_handler, {Handler, Options2}, Message)
+  end.


### PR DESCRIPTION
The main motivation of this pullrequest is as following:

If one is using cowboy middleware for example to do the logging of the http body - then the body will be no longer available through `cowboy_req:body/2` call. This pullrequest allows to provide Body by using  `soap_cowboy_1_protocol:upgrade/5` or `soap_cowboy_2_protocol:upgrade/7`. In this case extra tiny module will be needed from the user's side to read body from whether he stored it, and provide it down to the soap library.

For example in our case middleware that does the logging stores body with cowboy_req:meta/2.