### PR TITLE
Fix https in soap_parse_wsdl and soap_pars_wsdl_2_0

### DIFF
--- a/src/soap_parse_wsdl.erl
+++ b/src/soap_parse_wsdl.erl
@@ -614,6 +614,15 @@ get_url_file("http://"++_ = URL) ->
         {error, _Reason} ->
             {error, "failed to retrieve: "++URL}
         end;
+get_url_file("https://"++_ = URL) ->
+    case httpc:request(URL) of
+        {ok,{{_HTTP,200,_OK}, _Headers, Body}} ->
+            {ok, Body};
+        {ok,{{_HTTP, _RC, _Emsg}, _Headers, _Body}} ->
+            {error, "failed to retrieve: "++URL};
+        {error, _Reason} ->
+            {error, "failed to retrieve: "++URL}
+        end;
 get_url_file("file://" ++ F_name) ->
     case file:read_file(F_name) of
         {ok, Bin} ->

--- a/src/soap_parse_wsdl_2_0.erl
+++ b/src/soap_parse_wsdl_2_0.erl
@@ -376,6 +376,15 @@ get_url_file("http://"++_ = URL, _Options) ->
         {error, _Reason} ->
             {error, "failed to retrieve: "++URL}
     end;
+get_url_file("https://"++_ = URL, _Options) ->
+    case httpc:request(URL) of
+        {ok,{{_HTTP,200,_OK}, _Headers, Body}} ->
+            {ok, Body};
+        {ok,{{_HTTP,_RC,_Emsg}, _Headers, _Body}} ->
+            {error, "failed to retrieve: "++URL};
+        {error, _Reason} ->
+            {error, "failed to retrieve: "++URL}
+    end;
 get_url_file("file://" ++ F_name, Options) ->
     File_name = 
         case proplists:get_value(include_path, Options) of


### PR DESCRIPTION
I don't know if it's a bug or not. But here is my solution to my HTTPS soap url.